### PR TITLE
scripts Drop/Accept for IP tables run into issue due to ip address ch…

### DIFF
--- a/c1Accept.sh
+++ b/c1Accept.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-ipaddr=`dig +short c1.thousandeyes.com |grep -v .com`
-addresses=`echo $ipaddr | sed 's/ /,/'`
+#ipaddr=`dig +short c1.thousandeyes.com |grep -v .com`
+#addresses=`echo $ipaddr | sed 's/ /,/'`
+#iptables -D OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+
+sort -u known_c1_ip | while read address;
+do
 iptables -D OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+done

--- a/c1Drop.sh
+++ b/c1Drop.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
-ipaddr=`dig +short c1.thousandeyes.com |grep -v .com`
-addresses=`echo $ipaddr | sed 's/ /,/'`
+#ipaddr=`dig +short c1.thousandeyes.com |grep -v .com`
+#addresses=`echo $ipaddr | sed 's/ /,/'`
+#iptables -A OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+
+dig +short c1.thousandeyes.com |grep -v thousandeyes.com >> known_c1_ip
+sort -u known_c1_ip | while read address;
+do
 iptables -A OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+done

--- a/dataAccept.sh
+++ b/dataAccept.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-ipaddr=`dig +short data1.agt.thousandeyes.com |grep -v .com`
-echo $ipaddr | sed 's/ /\n/' | while read line; 
-  do
-  echo $line
-  iptables -D OUTPUT -d $line -p tcp --dport 443 -j DROP
-  done
+#ipaddr=`dig +short data1.agt.thousandeyes.com |grep -v .com`
+#echo $ipaddr | sed 's/ /\n/' | while read line;
+#  do
+#  echo $line
+#  iptables -D OUTPUT -d $line -p tcp --dport 443 -j DROP
+#  done
 
-
+sort -u known_data_ip | while read address;
+do
+iptables -D OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+done

--- a/dataDrop.sh
+++ b/dataDrop.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-ipaddr=`dig +short data1.agt.thousandeyes.com |grep -v .com`
-addresses=`echo $ipaddr | sed 's/ /,/'`
-echo $addresses
-iptables -A OUTPUT -d $addresses -p tcp --dport 443 -j DROP 2>&1
+#ipaddr=`dig +short data1.agt.thousandeyes.com |grep -v .com`
+#addresses=`echo $ipaddr | sed 's/ /,/'`
+#echo $addresses
+#iptables -A OUTPUT -d $addresses -p tcp --dport 443 -j DROP 2>&1
+
+dig +short data1.agt.thousandeyes.com |grep -v thousandeyes.com >> known_data_ip
+sort -u known_c1_ip | while read address;
+do
+iptables -A OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+done

--- a/registryAccept.sh
+++ b/registryAccept.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-ipaddr=`dig +short registry.agt.thousandeyes.com |grep -v thousandeyes.com`
-addresses=`echo $ipaddr | sed 's/ /,/'`
+#ipaddr=`dig +short registry.agt.thousandeyes.com |grep -v thousandeyes.com`
+#addresses=`echo $ipaddr | sed 's/ /,/'`
+#iptables -D OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+
+sort -u known_registry_ip | while read address;
+do
 iptables -D OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+done

--- a/registryDrop.sh
+++ b/registryDrop.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-
-ipaddr=`dig +short registry.agt.thousandeyes.com |grep -v thousandeyes.com`
-addresses=`echo $ipaddr | sed 's/ /,/'`
+#
+#ipaddr=`dig +short registry.agt.thousandeyes.com |grep -v thousandeyes.com`
+#addresses=`echo $ipaddr | sed 's/ /,/'`
+#iptables -A OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+### IP ADDRESSES OF THE registry.agt.thousandeyes.com change from time to time.
+# When this change is done while TSing or machine was powered off and address is changed,
+# above script will fail to remove ip as it is not in table. Hence new script that will store ip addresses
+dig +short registry.agt.thousandeyes.com |grep -v thousandeyes.com >> known_registry_ip
+sort -u known_registry_ip | while read address;
+do
 iptables -A OUTPUT -d $addresses -p tcp --dport 443 -j DROP
+done


### PR DESCRIPTION
…ange.

Explanation: IP ADDRESSES OF THE registry.agt.thousandeyes.com change from time to time. Previous script did dig and stored output to address variable.

When this change is done while TSing or machine was powered off and address is changed, above script will fail to remove iptables rules as it is not in table - it is doing dig and get new IP address! Hence, new script that will store ip addresses to a file, read from a file. I will add more improvements to check if rule exist before trying to remove.