### PR TITLE
nslookup for data1 and c1 returns urls with awsglobalaccelerator.com …

### DIFF
--- a/breakLab.sh
+++ b/breakLab.sh
@@ -6,7 +6,7 @@
 ./registryDrop.sh
 ./c1Drop.sh
 ./dataDrop.sh
-sleep 2
+sleep 5
 ./breakDNS.sh
 > /var/log/te-agent.log
 

--- a/c1Drop.sh
+++ b/c1Drop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-if dig +short c1.thousandeyes.com |grep -v thousandeyes.com;
-  then dig +short registry.agt.thousandeyes.com |grep -v thousandeyes.com |  while read address;
+if dig +short c1.thousandeyes.com |grep thousandeyes-v .com;
+  then dig +short registry.agt.thousandeyes.com |grep -v .com |  while read address;
   do
         if ! grep $address known_c1_ip;
         then

--- a/dataDrop.sh
+++ b/dataDrop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if dig +short data1.agt.thousandeyes.com |grep -v thousandeyes.com;
-  then dig +short data1.agt.thousandeyes.com |grep -v thousandeyes.com |  while read address;
+  then dig +short data1.agt.thousandeyes.com |grep -v .com |  while read address;
   do
         if ! grep $address known_data_ip;
         then

--- a/known_c1_ip
+++ b/known_c1_ip
@@ -1,6 +1,4 @@
-ab037f6da47723423.awsglobalaccelerator.com.
 99.83.133.153
 75.2.66.34
-ab037f6da47723423.awsglobalaccelerator.com.
 99.83.133.153
 75.2.66.34

--- a/known_data_ip
+++ b/known_data_ip
@@ -1,6 +1,4 @@
-a0d9392c0c2df89c7.dualstack.awsglobalaccelerator.com.
 13.248.204.16
 76.223.76.176
-a0d9392c0c2df89c7.dualstack.awsglobalaccelerator.com.
 76.223.76.176
 13.248.204.16


### PR DESCRIPTION
…which are not filtered. I used grep -v thousandeyes as before these were in DNS response. changed grep to grep -v .com to remove any that is not ip address.