### PR TITLE
nslookup for data1 and c1 returns urls with awsglobalaccelerator.com …

### DIFF
--- a/breakLab.sh
+++ b/breakLab.sh
@@ -6,7 +6,7 @@
 ./registryDrop.sh
 ./c1Drop.sh
 ./dataDrop.sh
-sleep 5
+sleep 10
 ./breakDNS.sh
 > /var/log/te-agent.log
 

--- a/registryDrop.sh
+++ b/registryDrop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if dig +short registry.agt.thousandeyes.com |grep -v thousandeyes.com;
-  then dig +short registry.agt.thousandeyes.com |grep -v thousandeyes.com |  while read address;
+  then dig +short registry.agt.thousandeyes.com |grep -v .com |  while read address;
   do
         if ! grep $address known_registry_ip;
         then


### PR DESCRIPTION
…which are not filtered. I used grep -v thousandeyes as before these were in DNS response. changed grep to grep -v .com to remove any that is not ip address.